### PR TITLE
allow non-string keys

### DIFF
--- a/example/convex/_generated/api.d.ts
+++ b/example/convex/_generated/api.d.ts
@@ -9,6 +9,7 @@
  */
 
 import type * as example from "../example.js";
+import type * as nested from "../nested.js";
 
 import type {
   ApiFromModules,
@@ -25,6 +26,7 @@ import type {
  */
 declare const fullApi: ApiFromModules<{
   example: typeof example;
+  nested: typeof nested;
 }>;
 declare const fullApiWithMounts: typeof fullApi;
 
@@ -43,20 +45,43 @@ export declare const components: {
       add: FunctionReference<
         "mutation",
         "internal",
-        { count: number; name: string; shards?: number },
+        { count: number; name: any; shards?: number },
         null
       >;
-      count: FunctionReference<"query", "internal", { name: string }, number>;
+      count: FunctionReference<"query", "internal", { name: any }, number>;
       estimateCount: FunctionReference<
         "query",
         "internal",
-        { name: string; readFromShards?: number; shards?: number },
+        { name: any; readFromShards?: number; shards?: number },
         any
       >;
       rebalance: FunctionReference<
         "mutation",
         "internal",
-        { name: string; shards?: number },
+        { name: any; shards?: number },
+        any
+      >;
+    };
+  };
+  nestedCounter: {
+    public: {
+      add: FunctionReference<
+        "mutation",
+        "internal",
+        { count: number; name: any; shards?: number },
+        null
+      >;
+      count: FunctionReference<"query", "internal", { name: any }, number>;
+      estimateCount: FunctionReference<
+        "query",
+        "internal",
+        { name: any; readFromShards?: number; shards?: number },
+        any
+      >;
+      rebalance: FunctionReference<
+        "mutation",
+        "internal",
+        { name: any; shards?: number },
         any
       >;
     };

--- a/example/convex/convex.config.ts
+++ b/example/convex/convex.config.ts
@@ -4,6 +4,7 @@ import migrations from "@convex-dev/migrations/convex.config";
 
 const app = defineApp();
 app.use(shardedCounter);
+app.use(shardedCounter, { name: "nestedCounter" });
 app.use(migrations);
 
 export default app;

--- a/example/convex/example.ts
+++ b/example/convex/example.ts
@@ -9,7 +9,7 @@ import { customCtx, customMutation } from "convex-helpers/server/customFunctions
 
 /// Example of ShardedCounter initialization.
 
-const counter = new ShardedCounter(components.shardedCounter, {
+const counter = new ShardedCounter<"beans" | "users" | "accomplishments">(components.shardedCounter, {
   shards: { beans: 10, users: 3 },
 });
 const numUsers = counter.for("users");

--- a/example/convex/nested.test.ts
+++ b/example/convex/nested.test.ts
@@ -1,0 +1,31 @@
+/// <reference types="vite/client" />
+
+import { convexTest } from "convex-test";
+import { describe, expect, test } from "vitest"
+import schema from "./schema";
+import componentSchema from "../../src/component/schema";
+import { api } from "./_generated/api";
+
+const modules = import.meta.glob("./**/*.ts");
+const componentModules = import.meta.glob("../../src/component/**/*.ts");
+
+describe("nested sharded counter", () => {
+  async function setupTest() {
+    const t = convexTest(schema, modules);
+    t.registerComponent("nestedCounter", componentSchema, componentModules);
+    return t;
+  }
+
+  test("follower and follows count", async () => {
+    const t = await setupTest();
+    const users = await t.run((ctx) => {
+      return Promise.all([
+        ctx.db.insert("users", { name: "1" }),
+        ctx.db.insert("users", { name: "2" }),
+        ctx.db.insert("users", { name: "3" }),
+      ]);
+    });
+    await t.mutation(api.nested.addFollower, { follower: users[0], follows: users[1] });
+    expect(await t.query(api.nested.countFollows, { user: users[0] })).toStrictEqual(1);
+  })
+});

--- a/example/convex/nested.test.ts
+++ b/example/convex/nested.test.ts
@@ -22,10 +22,11 @@ describe("nested sharded counter", () => {
       return Promise.all([
         ctx.db.insert("users", { name: "1" }),
         ctx.db.insert("users", { name: "2" }),
-        ctx.db.insert("users", { name: "3" }),
       ]);
     });
     await t.mutation(api.nested.addFollower, { follower: users[0], followee: users[1] });
     expect(await t.query(api.nested.countFollows, { user: users[0] })).toStrictEqual(1);
+    expect(await t.query(api.nested.countFollowers, { user: users[0] })).toStrictEqual(0);
+    expect(await t.query(api.nested.countFollowers, { user: users[1] })).toStrictEqual(1);
   })
 });

--- a/example/convex/nested.test.ts
+++ b/example/convex/nested.test.ts
@@ -25,7 +25,7 @@ describe("nested sharded counter", () => {
         ctx.db.insert("users", { name: "3" }),
       ]);
     });
-    await t.mutation(api.nested.addFollower, { follower: users[0], follows: users[1] });
+    await t.mutation(api.nested.addFollower, { follower: users[0], followee: users[1] });
     expect(await t.query(api.nested.countFollows, { user: users[0] })).toStrictEqual(1);
   })
 });

--- a/example/convex/nested.ts
+++ b/example/convex/nested.ts
@@ -1,0 +1,39 @@
+/// Example of a hierarchical counter.
+/// This is the same as a regular sharded counter (see example.ts), but the keys
+/// are tuples instead of strings.
+/// You cannot accumulate across a prefix of the tuple; if you want to do that,
+/// use an additional counter for each prefix, or use the Aggregate component:
+/// https://www.npmjs.com/package/@convex-dev/aggregate
+
+import { ShardedCounter } from "@convex-dev/sharded-counter";
+import { components } from "./_generated/api";
+import { Id } from "./_generated/dataModel";
+import { v } from "convex/values";
+import { mutation, query } from "./_generated/server";
+
+const nestedCounter = new ShardedCounter<[Id<"users">, "follows" | "followers"]>(
+  components.nestedCounter,
+  { defaultShards: 3 },
+);
+
+export const addFollower = mutation({
+  args: { follower: v.id("users"), follows: v.id("users") },
+  handler: async (ctx, { follower, follows }) => {
+    await nestedCounter.inc(ctx, [follows, "followers"]);
+    await nestedCounter.inc(ctx, [follower, "follows"]);
+  },
+});
+
+export const countFollows = query({
+  args: { user: v.id("users") },
+  handler: async (ctx, { user }) => {
+    return await nestedCounter.count(ctx, [user, "follows"]);
+  },
+});
+
+export const countFollowers = query({
+  args: { user: v.id("users") },
+  handler: async (ctx, { user }) => {
+    return await nestedCounter.count(ctx, [user, "followers"]);
+  },
+});

--- a/example/convex/nested.ts
+++ b/example/convex/nested.ts
@@ -17,9 +17,9 @@ const nestedCounter = new ShardedCounter<[Id<"users">, "follows" | "followers"]>
 );
 
 export const addFollower = mutation({
-  args: { follower: v.id("users"), follows: v.id("users") },
-  handler: async (ctx, { follower, follows }) => {
-    await nestedCounter.inc(ctx, [follows, "followers"]);
+  args: { follower: v.id("users"), followee: v.id("users") },
+  handler: async (ctx, { follower, followee }) => {
+    await nestedCounter.inc(ctx, [followee, "followers"]);
     await nestedCounter.inc(ctx, [follower, "follows"]);
   },
 });

--- a/example/package.json
+++ b/example/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@convex-dev/migrations": "^0.1.6",
     "@convex-dev/sharded-counter": "file:..",
-    "convex": "^1.17.0",
+    "convex": "file:../node_modules/convex",
     "convex-helpers": "^0.1.61",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"

--- a/example/package.json
+++ b/example/package.json
@@ -23,6 +23,7 @@
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react": "^4.3.1",
+    "convex-test": "^0.0.33",
     "eslint": "^9.9.0",
     "eslint-plugin-react-hooks": "^5.1.0-rc.0",
     "eslint-plugin-react-refresh": "^0.4.9",

--- a/package.json
+++ b/package.json
@@ -57,15 +57,15 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",
-    "@types/node": "^18.17.0",
-    "eslint": "^9.9.1",
-    "convex-test": "^0.0.31",
     "@fast-check/vitest": "^0.1.3",
+    "@types/node": "^18.17.0",
+    "convex-test": "^0.0.33",
+    "eslint": "^9.9.1",
     "globals": "^15.9.0",
-    "vitest": "^2.1.1",
     "prettier": "3.2.5",
     "typescript": "~5.0.3",
-    "typescript-eslint": "^8.4.0"
+    "typescript-eslint": "^8.4.0",
+    "vitest": "^2.1.1"
   },
   "main": "./dist/commonjs/client/index.js",
   "types": "./dist/commonjs/client/index.d.ts",

--- a/src/component/_generated/api.d.ts
+++ b/src/component/_generated/api.d.ts
@@ -31,20 +31,20 @@ export type Mounts = {
     add: FunctionReference<
       "mutation",
       "public",
-      { count: number; name: string; shards?: number },
+      { count: number; name: any; shards?: number },
       null
     >;
-    count: FunctionReference<"query", "public", { name: string }, number>;
+    count: FunctionReference<"query", "public", { name: any }, number>;
     estimateCount: FunctionReference<
       "query",
       "public",
-      { name: string; readFromShards?: number; shards?: number },
+      { name: any; readFromShards?: number; shards?: number },
       any
     >;
     rebalance: FunctionReference<
       "mutation",
       "public",
-      { name: string; shards?: number },
+      { name: any; shards?: number },
       any
     >;
   };

--- a/src/component/public.ts
+++ b/src/component/public.ts
@@ -5,7 +5,7 @@ export const DEFAULT_SHARD_COUNT = 16;
 
 export const add = mutation({
   args: {
-    name: v.string(),
+    name: v.any(),
     count: v.number(),
     shards: v.optional(v.number()),
   },
@@ -31,7 +31,7 @@ export const add = mutation({
 });
 
 export const count = query({
-  args: { name: v.string() },
+  args: { name: v.any() },
   returns: v.number(),
   handler: async (ctx, args) => {
     const counters = await ctx.db
@@ -43,7 +43,7 @@ export const count = query({
 });
 
 export const rebalance = mutation({
-  args: { name: v.string(), shards: v.optional(v.number()) },
+  args: { name: v.any(), shards: v.optional(v.number()) },
   handler: async (ctx, args) => {
     const counters = await ctx.db
       .query("counters")
@@ -73,7 +73,7 @@ export const rebalance = mutation({
 
 export const estimateCount = query({
   args: {
-    name: v.string(),
+    name: v.any(),
     readFromShards: v.optional(v.number()),
     shards: v.optional(v.number()),
   },

--- a/src/component/schema.ts
+++ b/src/component/schema.ts
@@ -3,7 +3,7 @@ import { v } from "convex/values";
 
 export default defineSchema({
   counters: defineTable({
-    name: v.string(),
+    name: v.any(),
     value: v.number(),
     shard: v.number(),
   }).index("name", ["name", "shard"]),


### PR DESCRIPTION
<!-- Describe your PR here. -->

enable ShardedCounter keys to be any type, not just strings. The type can be enforced in Typescript.

Added to readme.

Added example and test of nested counters, as requested in https://discord.com/channels/1019350475847499849/1298765828862247013/1298765828862247013

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
