### PR TITLE
million checkboxes ui

### DIFF
--- a/example/convex/_generated/api.d.ts
+++ b/example/convex/_generated/api.d.ts
@@ -8,6 +8,7 @@
  * @module
  */
 
+import type * as checkboxes from "../checkboxes.js";
 import type * as example from "../example.js";
 
 import type {
@@ -24,6 +25,7 @@ import type {
  * ```
  */
 declare const fullApi: ApiFromModules<{
+  checkboxes: typeof checkboxes;
   example: typeof example;
 }>;
 declare const fullApiWithMounts: typeof fullApi;
@@ -39,6 +41,29 @@ export declare const internal: FilterApi<
 
 export declare const components: {
   shardedCounter: {
+    public: {
+      add: FunctionReference<
+        "mutation",
+        "internal",
+        { count: number; name: string; shards?: number },
+        null
+      >;
+      count: FunctionReference<"query", "internal", { name: string }, number>;
+      estimateCount: FunctionReference<
+        "query",
+        "internal",
+        { name: string; readFromShards?: number; shards?: number },
+        any
+      >;
+      rebalance: FunctionReference<
+        "mutation",
+        "internal",
+        { name: string; shards?: number },
+        any
+      >;
+    };
+  };
+  checkboxCounter: {
     public: {
       add: FunctionReference<
         "mutation",

--- a/example/convex/checkboxes.ts
+++ b/example/convex/checkboxes.ts
@@ -1,0 +1,172 @@
+import { v } from "convex/values";
+import { internalMutation, mutation, query } from "./_generated/server";
+import { GenericMutationCtx } from "convex/server";
+import { DataModel } from "./_generated/dataModel";
+import { api, components } from "./_generated/api";
+import { ShardedCounter } from "@convex-dev/sharded-counter";
+
+export const NUM_BOXES = 1000000;
+export const BOXES_PER_DOCUMENT = 4000;
+export const NUM_DOCUMENTS = Math.floor(NUM_BOXES / BOXES_PER_DOCUMENT);
+
+const checkboxCounter = new ShardedCounter(components.checkboxCounter, {
+  shards: { checkboxes: 100 },
+}).for("checkboxes");
+
+export const countCheckedBoxes = query({
+  args: {},
+  returns: v.number(),
+  handler: async (ctx) => {
+    return await checkboxCounter.count(ctx);
+  },
+});
+
+export const get = query({
+  args: { documentIdx: v.number() },
+  handler: async (ctx, { documentIdx }) => {
+    if (documentIdx < 0 || documentIdx >= NUM_DOCUMENTS) {
+      throw new Error("documentIdx out of range");
+    }
+    return (
+      await ctx.db
+        .query("checkboxes")
+        .withIndex("idx", (q) => q.eq("idx", documentIdx))
+        .order("asc")
+        .first()
+    )?.boxes;
+  },
+});
+
+const toggleHandler = async (
+  ctx: GenericMutationCtx<DataModel>,
+  {
+    documentIdx,
+    arrayIdx,
+    checked,
+  }: {
+    documentIdx: number;
+    arrayIdx: number;
+    checked: boolean;
+  }
+) => {
+  if (documentIdx < 0 || documentIdx >= NUM_DOCUMENTS) {
+    throw new Error("documentIdx out of range");
+  }
+  if (arrayIdx < 0 || arrayIdx >= BOXES_PER_DOCUMENT) {
+    throw new Error("arrayIdx out of range");
+  }
+  let checkbox = await ctx.db
+    .query("checkboxes")
+    .withIndex("idx", (q) => q.eq("idx", documentIdx))
+    .first();
+
+  if (!checkbox) {
+    await ctx.db.insert("checkboxes", {
+      idx: documentIdx,
+      boxes: new Uint8Array(BOXES_PER_DOCUMENT / 8).buffer,
+    });
+    checkbox = await ctx.db
+      .query("checkboxes")
+      .withIndex("idx", (q) => q.eq("idx", documentIdx))
+      .first();
+  }
+  if (!checkbox) {
+    throw new Error("Failed to create checkbox");
+  }
+
+  const bytes = checkbox.boxes;
+  const view = new Uint8Array(bytes);
+  const newBytes = shiftBit(view, arrayIdx, checked)?.buffer;
+
+  if (newBytes) {
+    await ctx.db.patch(checkbox._id, {
+      idx: checkbox.idx,
+      boxes: newBytes,
+    });
+    if (checked) {
+      await checkboxCounter.inc(ctx);
+    } else {
+      await checkboxCounter.dec(ctx);
+    }
+  }
+};
+
+export const toggle = mutation({
+  args: { documentIdx: v.number(), arrayIdx: v.number(), checked: v.boolean() },
+  handler: toggleHandler,
+});
+
+export const seed = internalMutation({
+  args: {},
+  handler: async (ctx) => {
+    const boxes = await ctx.db
+      .query("checkboxes")
+      .withIndex("idx")
+      .order("asc")
+      .collect();
+    // Clear the table.
+    for (const box of boxes) {
+      await ctx.db.delete(box._id);
+    }
+
+    const bytes = new Uint8Array(BOXES_PER_DOCUMENT / 8);
+
+    // Reset the table.
+    for (let i = 0; i < NUM_DOCUMENTS; i++) {
+      await ctx.db.insert("checkboxes", {
+        idx: i,
+        boxes: bytes.buffer,
+      });
+    }
+  },
+});
+
+export const toggleRandom = internalMutation({
+  args: {},
+  handler: async (ctx) => {
+    for (let i = 0; i < 10; i++) {
+      const documentIdx = Math.floor(Math.random() * NUM_DOCUMENTS);
+      const arrayIdx = Math.floor(Math.random() * 2);
+      const box = await ctx.db
+        .query("checkboxes")
+        .withIndex("idx", (q) => q.eq("idx", documentIdx))
+        .first();
+      if (box) {
+        const jitter = Math.random() * 100000;
+        ctx.scheduler.runAfter(jitter, api.checkboxes.toggle, {
+          documentIdx,
+          arrayIdx,
+          checked: !isChecked(new Uint8Array(box.boxes), arrayIdx),
+        });
+      }
+    }
+  },
+});
+
+export const isChecked = (view: Uint8Array, arrayIdx: number) => {
+  const bit = arrayIdx % 8;
+  const uintIdx = Math.floor(arrayIdx / 8);
+  const byte = view ? view[uintIdx] : 0;
+  const shiftedBit = 1 << bit;
+  return !!(shiftedBit & byte);
+};
+
+export const shiftBit = (
+  view: Uint8Array,
+  arrayIdx: number,
+  checked: boolean
+) => {
+  const bit = arrayIdx % 8;
+  const uintIdx = Math.floor(arrayIdx / 8);
+  const byte = view[uintIdx];
+  const shiftedBit = 1 << bit;
+  const isCurrentlyChecked = isChecked(view, arrayIdx);
+
+  // If the bit is already in the correct state, do nothing to avoid OCC.
+  if (isCurrentlyChecked === checked) {
+    return;
+  }
+
+  view[uintIdx] = shiftedBit ^ byte;
+  return view;
+};

--- a/example/convex/convex.config.ts
+++ b/example/convex/convex.config.ts
@@ -4,6 +4,7 @@ import migrations from "@convex-dev/migrations/convex.config";
 
 const app = defineApp();
 app.use(shardedCounter);
+app.use(shardedCounter, { name: "checkboxCounter" });
 app.use(migrations);
 
 export default app;

--- a/example/convex/schema.ts
+++ b/example/convex/schema.ts
@@ -11,5 +11,9 @@ export default defineSchema(
       id: v.string(),
       isDone: v.boolean(),
     }),
+    checkboxes: defineTable({
+      idx: v.number(),
+      boxes: v.bytes(),
+    }).index("idx", ["idx"]),
   },
 );

--- a/example/package.json
+++ b/example/package.json
@@ -4,8 +4,9 @@
   "type": "module",
   "version": "0.0.0",
   "scripts": {
-    "dev": "convex dev --live-component-sources",
+    "dev:backend": "convex dev --live-component-sources",
     "dev:frontend": "vite",
+    "dev": "npm-run-all --parallel dev:backend dev:frontend",
     "logs": "convex logs",
     "lint": "tsc -p convex && eslint convex"
   },
@@ -15,18 +16,22 @@
     "convex": "^1.17.0",
     "convex-helpers": "^0.1.61",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "react-use": "^17.5.1",
+    "react-window": "^1.8.10"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.1.0",
     "@eslint/js": "^9.9.0",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
+    "@types/react-window": "^1.8.8",
     "@vitejs/plugin-react": "^4.3.1",
     "eslint": "^9.9.0",
     "eslint-plugin-react-hooks": "^5.1.0-rc.0",
     "eslint-plugin-react-refresh": "^0.4.9",
     "globals": "^15.9.0",
+    "npm-run-all": "^4.1.5",
     "typescript": "^5.5.0",
     "typescript-eslint": "^8.0.1",
     "vite": "^5.4.1"

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -138,7 +138,7 @@ function App() {
           <div style={{ marginLeft: "auto" }}>
             source code on{" "}
             <a
-              href="https://github.com/atrakh/one-million-checkboxes"
+              href="https://github.com/get-convex/sharded-counter"
               target="_blank"
             >
               GitHub

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,0 +1,247 @@
+// From https://github.com/atrakh/one-million-checkboxes
+
+import { FixedSizeGrid as Grid } from "react-window";
+import { useMutation, useQueries, useQuery } from "convex/react";
+import { api } from "../convex/_generated/api";
+import {
+  NUM_BOXES,
+  NUM_DOCUMENTS,
+  isChecked,
+  shiftBit,
+} from "../convex/checkboxes";
+import React, { useMemo } from "react";
+import { useMeasure } from "react-use";
+
+function App() {
+  const queries = useMemo(
+    () =>
+      Array(NUM_DOCUMENTS)
+        .fill(null)
+        .map((_, idx) => ({
+          query: api.checkboxes.get,
+          args: { documentIdx: idx },
+        }))
+        .reduce(
+          (acc, curr) => ({ ...acc, [curr.args.documentIdx.toString()]: curr }),
+          {}
+        ),
+    []
+  );
+
+  const boxRecord = useQueries(queries);
+  const boxes = Object.entries(boxRecord).map(([, value]) => value);
+
+  const numCheckedBoxes = useQuery(api.checkboxes.countCheckedBoxes);
+
+  const [ref, { width, height }] = useMeasure<HTMLDivElement>();
+
+  const numColumns = Math.ceil((width - 40) / 30);
+  const numRows = Math.ceil(NUM_BOXES / numColumns);
+
+  return (
+    <div
+      key={`${width}-${height}`}
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: "0.25rem",
+        height: "95vh",
+        width: "99vw",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+        }}
+      >
+        <div>
+          <div style={{ fontWeight: "bold", marginBottom: "0.25rem" }}>
+            One Million Checkboxes
+          </div>
+          <div>{numCheckedBoxes} boxes checked</div>
+        </div>
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+          }}
+        >
+          <a
+            style={{
+              display: "flex",
+              alignItems: "center",
+              textDecoration: "none",
+              color: "black",
+            }}
+            href="https://convex.dev"
+            target="_blank"
+          >
+            Powered by
+            <svg
+              width="128px"
+              height="100%"
+              viewBox="0 0 600 150"
+              version="1.1"
+              xmlns="http://www.w3.org/2000/svg"
+              style={{
+                fillRule: "evenodd",
+                clipRule: "evenodd",
+                strokeLinejoin: "round",
+                strokeMiterlimit: 2,
+              }}
+            >
+              <g>
+                <path
+                  d="M512.51,75.13L490.32,45.75L516.04,45.75L561.43,105.52L535.46,105.52L525.37,92.15L515.28,105.52L489.43,105.52L512.51,75.13Z"
+                  style={{ fillRule: "nonzero" }}
+                />
+                <path
+                  d="M534.89,45.75L560.49,45.75L540.84,71.92L527.84,55.15L534.89,45.75Z"
+                  style={{ fillRule: "nonzero" }}
+                />
+              </g>
+              <path
+                d="M159.9,98.9C153.72,93.65 150.63,85.89 150.63,75.64C150.63,65.39 153.78,57.63 160.09,52.38C166.39,47.13 175.01,44.5 185.94,44.5C190.48,44.5 194.49,44.81 197.98,45.45C201.47,46.08 204.81,47.15 208,48.67L208,65.3C203.04,62.95 197.41,61.77 191.11,61.77C185.56,61.77 181.46,62.82 178.82,64.92C176.17,67.02 174.85,70.59 174.85,75.64C174.85,80.52 176.15,84.05 178.76,86.23C181.36,88.42 185.48,89.51 191.12,89.51C197.09,89.51 202.76,88.12 208.14,85.35L208.14,102.75C202.17,105.44 194.73,106.78 185.82,106.78C174.71,106.78 166.08,104.15 159.9,98.9Z"
+                style={{ fillRule: "nonzero" }}
+              />
+              <path
+                d="M213.52,75.63C213.52,65.46 216.42,57.73 222.22,52.43C228.02,47.13 236.76,44.49 248.45,44.49C260.22,44.49 269.02,47.14 274.87,52.43C280.71,57.72 283.63,65.46 283.63,75.63C283.63,96.39 271.9,106.77 248.45,106.77C225.16,106.78 213.52,96.4 213.52,75.63ZM256.84,86.23C258.56,84.04 259.42,80.51 259.42,75.64C259.42,70.85 258.56,67.34 256.84,65.11C255.12,62.88 252.32,61.77 248.45,61.77C244.67,61.77 241.93,62.89 240.25,65.11C238.57,67.34 237.73,70.85 237.73,75.64C237.73,80.52 238.57,84.05 240.25,86.23C241.93,88.42 244.66,89.51 248.45,89.51C252.32,89.51 255.11,88.41 256.84,86.23Z"
+                style={{ fillRule: "nonzero" }}
+              />
+              <path
+                d="M289.15,45.75L311.34,45.75L311.97,50.29C314.41,48.61 317.52,47.22 321.3,46.13C325.08,45.04 328.99,44.49 333.03,44.49C340.51,44.49 345.97,46.34 349.42,50.04C352.87,53.74 354.59,59.45 354.59,67.19L354.59,105.52L330.89,105.52L330.89,69.58C330.89,66.89 330.28,64.96 329.06,63.78C327.84,62.6 325.8,62.02 322.94,62.02C321.18,62.02 319.37,62.42 317.52,63.22C315.67,64.02 314.12,65.05 312.85,66.31L312.85,105.52L289.15,105.52L289.15,45.75Z"
+                style={{ fillRule: "nonzero" }}
+              />
+              <path
+                d="M354.66,45.75L379.37,45.75L390.72,80.8L402.07,45.75L426.78,45.75L403.2,105.52L378.23,105.52L354.66,45.75Z"
+                style={{ fillRule: "nonzero" }}
+              />
+              <path
+                d="M434.24,100.38C427.12,95.04 423.79,85.77 423.79,75.76C423.79,66.01 426.44,57.98 432.49,52.43C438.54,46.88 447.76,44.49 459.4,44.49C470.11,44.49 478.53,46.97 484.68,51.93C490.82,56.89 493.9,63.66 493.9,72.23L493.9,82.7L448.83,82.7C449.95,85.81 451.37,88.06 454.86,89.45C458.35,90.84 463.22,91.53 469.45,91.53C473.17,91.53 476.97,91.24 480.83,90.65C482.19,90.44 484.43,90.11 485.61,89.86L485.61,104.39C479.72,105.99 471.87,106.79 463.02,106.79C451.11,106.78 441.36,105.72 434.24,100.38ZM469,69.84C469,66.88 465.59,60.51 458.74,60.51C452.56,60.51 448.48,66.78 448.48,69.84L469,69.84Z"
+                style={{ fillRule: "nonzero" }}
+              />
+              <path
+                d="M100.22,100.4C113.32,98.97 125.67,92.11 132.47,80.66C129.25,108.98 97.74,126.88 72.02,115.89C69.65,114.88 67.61,113.2 66.21,111.04C60.43,102.12 58.53,90.77 61.26,80.47C69.06,93.7 84.92,101.81 100.22,100.4Z"
+                style={{ fill: "rgb(243,176,28)", fillRule: "nonzero" }}
+              />
+              <path
+                d="M60.78,72.16C55.47,84.22 55.24,98.34 61.75,109.96C38.84,93.02 39.09,56.77 61.47,40C63.54,38.45 66,37.53 68.58,37.39C79.19,36.84 89.97,40.87 97.53,48.38C82.17,48.53 67.21,58.2 60.78,72.16Z"
+                style={{ fill: "rgb(141,38,118)", fillRule: "nonzero" }}
+              />
+              <path
+                d="M104.94,52.09C97.19,41.47 85.06,34.24 71.77,34.02C97.46,22.56 129.06,41.14 132.5,68.61C132.82,71.16 132.4,73.76 131.25,76.06C126.45,85.64 117.55,93.07 107.15,95.82C114.77,81.93 113.83,64.96 104.94,52.09Z"
+                style={{ fill: "rgb(238,52,47)", fillRule: "nonzero" }}
+              />
+            </svg>
+          </a>
+          <div style={{ marginLeft: "auto" }}>
+            source code on{" "}
+            <a
+              href="https://github.com/atrakh/one-million-checkboxes"
+              target="_blank"
+            >
+              GitHub
+            </a>
+          </div>
+        </div>
+      </div>
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          flexGrow: 1,
+        }}
+        ref={ref}
+      >
+        <Grid
+          columnCount={numColumns}
+          columnWidth={30}
+          height={height}
+          rowCount={numRows}
+          rowHeight={30}
+          width={width}
+          itemData={{ flattenedBoxes: boxes, numColumns, numRows }}
+        >
+          {Cell}
+        </Grid>
+      </div>
+    </div>
+  );
+}
+
+const Cell = ({
+  style,
+  rowIndex,
+  columnIndex,
+  data,
+}: {
+  style: React.CSSProperties;
+  rowIndex: number;
+  columnIndex: number;
+  data: { flattenedBoxes: ArrayBuffer[]; numColumns: number; numRows: number };
+}) => {
+  const { flattenedBoxes, numColumns } = data;
+  const index = rowIndex * numColumns + columnIndex;
+  const documentIdx = index % NUM_DOCUMENTS;
+  const arrayIdx = Math.floor(index / NUM_DOCUMENTS);
+  const document = flattenedBoxes[documentIdx];
+  const view = document === undefined ? undefined : new Uint8Array(document);
+
+  const isCurrentlyChecked = view && isChecked(view, arrayIdx);
+
+  const isLoading = view === undefined;
+
+  const toggle = useMutation(api.checkboxes.toggle).withOptimisticUpdate(
+    (localStore) => {
+      const currentValue = localStore.getQuery(api.checkboxes.get, {
+        documentIdx,
+      });
+      if (currentValue !== undefined && currentValue !== null) {
+        const view = new Uint8Array(currentValue);
+        const newBytes = shiftBit(view, arrayIdx, !isCurrentlyChecked)?.buffer;
+        if (newBytes) {
+          localStore.setQuery(api.checkboxes.get, { documentIdx }, newBytes);
+
+          let count = localStore.getQuery(api.checkboxes.countCheckedBoxes);
+          if (count !== undefined) {
+            if (isCurrentlyChecked) {
+              count--;
+            } else {
+              count++;
+            }
+            localStore.setQuery(api.checkboxes.countCheckedBoxes, {}, count);
+          }
+        }
+      }
+    }
+  );
+  if (index >= NUM_BOXES) {
+    return null;
+  }
+  const onClick = () => {
+    void toggle({ documentIdx, arrayIdx, checked: !isCurrentlyChecked });
+  };
+  return (
+    <div
+      style={style}
+      key={`${documentIdx}-${arrayIdx}`}
+      id={`${documentIdx}-${arrayIdx}`}
+    >
+      <input
+        style={{
+          margin: "0.25rem",
+          cursor: isLoading ? undefined : "pointer",
+          width: "24px",
+          height: "24px",
+          padding: "8px",
+        }}
+        type="checkbox"
+        checked={isCurrentlyChecked}
+        disabled={isLoading}
+        onChange={onClick}
+      />
+    </div>
+  );
+};
+export default App;

--- a/example/src/index.css
+++ b/example/src/index.css
@@ -1,0 +1,111 @@
+/* reset */
+* {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  line-height: 1.5;
+}
+
+body {
+  font-family: system-ui, "Segoe UI", Roboto, "Helvetica Neue", helvetica,
+    sans-serif;
+}
+
+main {
+  padding-top: 1em;
+  padding-bottom: 1em;
+  width: min(800px, 95vw);
+  margin: 0 auto;
+}
+
+h1 {
+  text-align: center;
+  margin-bottom: 8px;
+  font-size: 1.8em;
+  font-weight: 500;
+}
+
+.badge {
+  text-align: center;
+  margin-bottom: 16px;
+}
+.badge span {
+  background-color: #212529;
+  color: #ffffff;
+  border-radius: 6px;
+  font-weight: bold;
+  padding: 4px 8px 4px 8px;
+  font-size: 0.75em;
+}
+
+ul {
+  margin: 8px;
+  border-radius: 8px;
+  border: solid 1px lightgray;
+  box-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.075);
+}
+
+ul:empty {
+  display: none;
+}
+
+li {
+  display: flex;
+  justify-content: flex-start;
+  padding: 8px 16px 8px 16px;
+  border-bottom: solid 1px lightgray;
+  font-size: 16px;
+}
+
+li:last-child {
+  border: 0;
+}
+
+li span:nth-child(1) {
+  font-weight: bold;
+  margin-right: 4px;
+  white-space: nowrap;
+}
+li span:nth-child(2) {
+  margin-right: 4px;
+  word-break: break-word;
+}
+li span:nth-child(3) {
+  color: #6c757d;
+  margin-left: auto;
+  white-space: nowrap;
+}
+
+form {
+  display: flex;
+  justify-content: center;
+}
+
+input:not([type]) {
+  padding: 6px 12px 6px 12px;
+  color: rgb(33, 37, 41);
+  border: solid 1px rgb(206, 212, 218);
+  border-radius: 8px;
+  font-size: 16px;
+}
+
+input[type="submit"],
+button {
+  margin-left: 4px;
+  background: lightblue;
+  color: white;
+  padding: 6px 12px 6px 12px;
+  border-radius: 8px;
+  font-size: 16px;
+  background-color: rgb(49, 108, 244);
+}
+
+input[type="submit"]:hover,
+button:hover {
+  background-color: rgb(41, 93, 207);
+}
+
+input[type="submit"]:disabled,
+button:disabled {
+  background-color: rgb(122, 160, 248);
+}

--- a/example/src/main.tsx
+++ b/example/src/main.tsx
@@ -1,0 +1,17 @@
+import { StrictMode } from "react";
+import ReactDOM from "react-dom/client";
+import "./index.css";
+import App from "./App";
+import { ConvexProvider, ConvexReactClient } from "convex/react";
+
+const address = import.meta.env.VITE_CONVEX_URL;
+
+const convex = new ConvexReactClient(address);
+
+ReactDOM.createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <ConvexProvider client={convex}>
+      <App />
+    </ConvexProvider>
+  </StrictMode>,
+);

--- a/example/src/vite-env.d.ts
+++ b/example/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
<!-- Describe your PR here. -->

customers are requesting an example repo for a component that has a UI, so let's give them one.

shamelessly copied from https://github.com/atrakh/one-million-checkboxes

two small changes:
- it uses the ShardedCounter component to track the count. kind of redundant since the UI already subscribes to all of the data, but if we shifted the query to be paginated this would be useful. and it's a good example of the component.
- create checkbox data lazily instead of requiring you to call `seed`
- 
<img width="1665" alt="Screenshot 2024-11-04 at 7 05 59 PM" src="https://github.com/user-attachments/assets/4a1d9170-ae20-490b-9813-c8dfb2dbdea7">

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
